### PR TITLE
feat: add "copy without @" setting

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -28,6 +28,7 @@
     const searchWrapper = document.querySelector('.search-wrapper');
     const sortControls = document.querySelector('.sort-controls');
     const clearSearchBtn = document.getElementById('clear-search-btn');
+    const copyToggleBtn = document.getElementById('copy-toggle-btn');
     let allItems = [];
     const galleryTitle = document.getElementById('gallery-title');
     let itemsSortedByWorks = []; 
@@ -50,6 +51,7 @@
     const FOLDERS_PANEL_VISIBLE_KEY = 'foldersPanelVisible';
     let isJumpingToArtist = false; // Флаг для отслеживания состояния "прыжка"
     let isFoldersPanelVisible = true; // Состояние видимости панели папок
+    let copyWithAtSign = true; // prefix copied artist names with `@`
     const SORT_DIRECTION_KEY = 'sortDirection';
 
     // --- Глобальные переменные для доступа из других скриптов ---
@@ -258,7 +260,7 @@
                 }
             } else {
                 // Стандартное поведение: копирование имени и сброс выделения
-                navigator.clipboard.writeText('@' + item.artist).then(() => {
+                navigator.clipboard.writeText((copyWithAtSign ? '@' : '') + item.artist).then(() => {
                     showToast('Artist name copied to clipboard!');
                 });
                 // Сбрасываем выделение, если кликнули без Ctrl
@@ -1026,6 +1028,32 @@
             e.target.blur();
         }
     });
+
+    function toggleCopyWithAtSign() {
+        copyWithAtSign = !copyWithAtSign;
+        localStorage.setItem('copyWithAtSign', copyWithAtSign);
+        updateCopyToggleButton();
+    }
+
+    function updateCopyToggleButton() {
+        if (copyWithAtSign) {
+            copyToggleBtn.classList.remove('off');
+            copyToggleBtn.classList.add('on');
+            copyToggleBtn.title = 'Copy with @';
+        } else {
+            copyToggleBtn.classList.remove('on');
+            copyToggleBtn.classList.add('off');
+            copyToggleBtn.title = 'Copy without @';
+        }
+    }
+
+    const savedCopyWithAtSign = localStorage.getItem('copyWithAtSign');
+    if (savedCopyWithAtSign !== null) {
+        copyWithAtSign = savedCopyWithAtSign === 'true';
+    }
+
+    copyToggleBtn.addEventListener('click', toggleCopyWithAtSign);
+    updateCopyToggleButton();
 
     // --- Логика перехода к номеру ---
     function handleJump(isReset = false) {

--- a/app/style.css
+++ b/app/style.css
@@ -1570,7 +1570,6 @@ input[type="range"]::-webkit-slider-thumb {
     font-size: 14px;
     font-weight: 600;
     line-height: 1;
-    color: var(--secondary-text-color);
     transition: color 0.2s;
     pointer-events: none;
     z-index: 1;
@@ -1592,13 +1591,14 @@ input[type="range"]::-webkit-slider-thumb {
     left: 2px;
 }
 
-.toggle-switch.off .toggle-label-left {
+.toggle-switch.off {
+    color: var(--secondary-text-color);
+}
+
+.toggle-switch.on {
     color: var(--accent-color);
 }
 
-.toggle-switch.off .toggle-label-right {
-    color: var(--secondary-text-color);
-}
 
 .toggle-switch.on .toggle-thumb {
     left: calc(100% - 26px - 2px);
@@ -1607,14 +1607,6 @@ input[type="range"]::-webkit-slider-thumb {
 
 .toggle-switch.on .toggle-track {
     border-color: var(--accent-color);
-}
-
-.toggle-switch.on .toggle-label-right {
-    color: var(--accent-color);
-}
-
-.toggle-switch.on .toggle-label-left {
-    color: var(--secondary-text-color);
 }
 
 .toggle-switch:hover .toggle-track {

--- a/app/style.css
+++ b/app/style.css
@@ -194,9 +194,9 @@ body::-webkit-scrollbar-thumb {
 
 .sort-jump-group {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 15px;
-    width: 270px; /* Увеличиваем ширину, чтобы вместить кнопки сортировки */
+    justify-content: center;
 }
 /* Контейнер для кнопки экспорта TXT, который теперь в левой колонке */
 #txt-export-container {
@@ -1521,4 +1521,115 @@ input[type="range"]::-webkit-slider-thumb {
     border-color: var(--accent-color);
     color: var(--accent-color);
     background-color: rgba(10, 132, 255, 0.05);
+}
+
+.copy-toggle {
+    display: flex;
+    align-items: center;
+}
+
+.toggle-switch {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    width: 64px;
+    height: 32px;
+    position: relative;
+    outline: none;
+}
+
+.toggle-track {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 32px;
+    position: relative;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 26px;
+    height: 26px;
+    background: var(--text-color);
+    border-radius: 50%;
+    transition: left 0.2s ease, background-color 0.2s, filter 0.2s;
+    z-index: 2;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.toggle-label {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--secondary-text-color);
+    transition: color 0.2s;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.toggle-label-left {
+    left: 10px;
+}
+
+.toggle-label-right {
+    right: 10px;
+}
+
+.strike {
+    text-decoration: line-through;
+}
+
+.toggle-switch.off .toggle-thumb {
+    left: 2px;
+}
+
+.toggle-switch.off .toggle-label-left {
+    color: var(--accent-color);
+}
+
+.toggle-switch.off .toggle-label-right {
+    color: var(--secondary-text-color);
+}
+
+.toggle-switch.on .toggle-thumb {
+    left: calc(100% - 26px - 2px);
+    background: var(--accent-color);
+}
+
+.toggle-switch.on .toggle-track {
+    border-color: var(--accent-color);
+}
+
+.toggle-switch.on .toggle-label-right {
+    color: var(--accent-color);
+}
+
+.toggle-switch.on .toggle-label-left {
+    color: var(--secondary-text-color);
+}
+
+.toggle-switch:hover .toggle-track {
+    border-color: var(--accent-color);
+}
+
+.toggle-switch:hover .toggle-thumb {
+    background: var(--accent-color);
+}
+
+.toggle-switch.on:hover .toggle-thumb {
+    filter: brightness(1.2);
+    background: var(--accent-color);
+}
+
+.toggle-switch.on:hover .toggle-track {
+    border-color: var(--accent-color);
 }

--- a/index.html
+++ b/index.html
@@ -81,6 +81,15 @@
                     <button id="export-txt-btn" class="sort-button" title="Export artist names to a .txt file">Export .txt</button>
                 </div>
             </div>
+            <div class="copy-toggle">
+                <button id="copy-toggle-btn" class="toggle-switch" aria-label="Toggle copy with @">
+                    <span class="toggle-track">
+                        <span class="toggle-thumb"></span>
+                        <span class="toggle-label toggle-label-left">@</span>
+                        <span class="toggle-label toggle-label-right"><span class="strike">@</span></span>
+                    </span>
+                </button>
+            </div>
         </div>
         <div class="search-and-import-wrapper">
             <div class="search-wrapper">


### PR DESCRIPTION
Since @-syntax is unique to Anima (as far as I know), but many other models also support artist tags, I added this button to copy artist tags without @. By default it's off (copy with @ by default)

<img width="374" height="289" alt="image" src="https://github.com/user-attachments/assets/49c9fa2f-bcb4-43a7-9a36-f20e1d5bd2fe" />